### PR TITLE
Updates to get spectrometer working in May 2021

### DIFF
--- a/scripts/spectrometer.py
+++ b/scripts/spectrometer.py
@@ -258,11 +258,6 @@ class SpectrometerServer(DeviceServer):
             off = np.where(nd_on == 0)[0]
             if min(len(on), len(off)) < 8:
                 continue
-            # intervals = np.r_[np.diff(timestamps), np.inf]
-            # on_time = min(intervals[on])
-            # off_time = min(intervals[off])
-            # on_accums = on_time * self._dig_time_scale / (2. * N_CHANS)
-            # off_accums = off_time * self._dig_time_scale / (2. * N_CHANS)
             broadcast = (slice(None),) + (data.ndim - 1) * (np.newaxis,)
             logger.info('n_accs[on]:  %s', n_accs[on][:4])
             logger.info('n_accs[off]: %s', n_accs[off][:4])

--- a/scripts/spectrometer.py
+++ b/scripts/spectrometer.py
@@ -209,9 +209,8 @@ class SpectrometerServer(DeviceServer):
         self._telstate.add('pols', POL_ORDERING, immutable=True)
         self._telstate.add('n_chans', N_CHANS, immutable=True)
         self._telstate.add('knots', self._knots, immutable=True)
-        # XXX What do you mean it's not L-band???
-        self._telstate.add('center_freq', 1284e6, immutable=True)
-        self._telstate.add('bandwidth', 856e6, immutable=True)
+        self._telstate.add('center_freq', cbf_telstate['center_freq'], immutable=True)
+        self._telstate.add('bandwidth', cbf_telstate['bandwidth'], immutable=True)
 
     def process_l0_dump(self, heaps):
         """Turn an L0 dump worth of heaps into spectrometer products."""


### PR DESCRIPTION
This now supports the `n_accs` SPEAD item, removes hardcoded CBF settings (L band, wide) and adds the `--capture-heaps` debug option.

It allowed a successful test of the ECP64 functionality on 12 May 2021.

I'm merging this so long to keep things clean and up to date.